### PR TITLE
Fix rda-apps-clients submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "pm25/3rd Place/nbs/rda-apps-clients"]
+	path = pm25/3rd Place/nbs/rda-apps-clients
+	url = https://github.com/NCAR/rda-apps-clients.git


### PR DESCRIPTION
This submodule was a broken link, for some reason. 

Fixed by:

- `git rm --cached pm25/3rd\ Place/nbs/rda-apps-clients/` and committing
- `git submodule add https://github.com/NCAR/rda-apps-clients.git pm25/3rd\ Place/nbs/rda-apps-clients/` and committing